### PR TITLE
Corrections Feb9

### DIFF
--- a/frontend/website/components/forms/submissionForm.js
+++ b/frontend/website/components/forms/submissionForm.js
@@ -269,7 +269,6 @@ export default function SubmissionForm(props) {
                 setSeverity("error");
                 setMessage(response.message);
                 setOpenSnackbar(true);
-                alert('error')
             }
         }
         else {

--- a/frontend/website/components/forms/submissionForm.js
+++ b/frontend/website/components/forms/submissionForm.js
@@ -144,7 +144,6 @@ export default function SubmissionForm(props) {
 
             if (props.isAConnection) {
 
-                console.log('shoudl be setting noe')
                 setSuggestions(response.suggestions.map((x) =>
                     <Button onClick={handleAutoSuggestClick} id={x.id} title={x.label}>
                         {x.label}
@@ -152,7 +151,6 @@ export default function SubmissionForm(props) {
                 ));
             }
             else {
-                console.log('looking for suggestiong for : ', text)
 
                 setSubmissionProps({
                     submissionSuggestions:
@@ -327,12 +325,10 @@ export default function SubmissionForm(props) {
 
     useEffect(() => {
 
-        console.log('submissionIncomingConnections has changed: ', submissionIncomingConnections)
+        // console.log('submissionIncomingConnections has changed: ', submissionIncomingConnections)
 
     }, [submissionIncomingConnections]);
 
-    // document.querySelectorAll('input[type=text], textarea').forEach(field => field.spellcheck = true);
-    // document.querySelectorAll('w-md-editor-text').forEach(field => field.style = {"min-height": "200px"});
 
     return (
 

--- a/frontend/website/components/submissions/addConnectionButton.js
+++ b/frontend/website/components/submissions/addConnectionButton.js
@@ -14,8 +14,8 @@ const AddConnectionsButton = ({ setSelectedOption }) => {
         = useSubmissionStore();
 
     const { connectionDescription, setConnectionDescription } =
-        useState(`Reply to [${submissionTitle}](${WEBSITE_URL}+'submissions/'+${submissionId}})`);
-    // useState(`Reply to [[${submissionTitle}]]` + ' ');
+        useState(`[${submissionTitle}](${WEBSITE_URL}+'submissions/'+${submissionId}})`);
+    // useState(`[[${submissionTitle}]]` + ' ');
 
     const handleButtonClick = () => {
         // setSubmissionProps({ submissionMode: "create" });
@@ -30,9 +30,13 @@ const AddConnectionsButton = ({ setSelectedOption }) => {
         <>
             <Box minWidth={'750px'}>
                 <Button
-                    onClick={handleButtonClick} variant="contained" size="small" endIcon={<ReplyAllOutlined />}>
-                    Add Incoming Connection
-
+                    onClick={handleButtonClick}
+                    variant="contained"
+                    size="small"
+                    endIcon={<ReplyAllOutlined />}
+                    style={{ textTransform: 'none' }}
+                >
+                    Make Submission with Mention
                 </Button>
 
                 <Slide direction="left" in={isTextBoxVisible} mountOnEnter unmountOnExit>
@@ -43,7 +47,7 @@ const AddConnectionsButton = ({ setSelectedOption }) => {
                             setTextBoxVisible={setTextBoxVisible}
                             source_url=""
                             title=""
-                            description={`Reply to [${submissionTitle}](${WEBSITE_URL}submissions/${submissionId})`}
+                            description={`[${submissionTitle}](${WEBSITE_URL}submissions/${submissionId})`}
                             communitiesNameMap={submissionCommunitiesNameMap}
                         />
 

--- a/frontend/website/components/submissions/connections.js
+++ b/frontend/website/components/submissions/connections.js
@@ -10,21 +10,16 @@ import { BASE_URL_CLIENT, BASE_URL_SERVER, SEARCH_ENDPOINT } from '../../static/
 
 export default function Connections({ submissionDataResponse, id }) {
     const { submissionId, submissionIncomingConnections, submissionOutgoingConnections, setSubmissionProps } = useSubmissionStore();
-    const [count, setCount] = useState(0);
 
     useEffect(() => {
     }, [submissionIncomingConnections]);
 
     useEffect(() => {
-        console.log('called :' + count)
-        console.log(submissionId)
-        setCount(count + 1);
         getIncomingConnections();
     }, [submissionId])
 
     async function getIncomingConnections() {
 
-        // var searchURL = BASE_URL_SERVER + SEARCH_ENDPOINT;
 
         var searchURL = BASE_URL_CLIENT + SEARCH_ENDPOINT + "?";
 
@@ -35,10 +30,6 @@ export default function Connections({ submissionDataResponse, id }) {
 
             searchURL += "&page=0";
         }
-        // else {
-        //     searchURL += "query=" + "";
-        // }
-
 
         const res = await fetch(searchURL, {
             headers: new Headers({
@@ -47,7 +38,7 @@ export default function Connections({ submissionDataResponse, id }) {
         });
 
         if (res.status == 200) {
-            console.log(res)
+
             const data = await res.json();
             setSubmissionProps({ submissionIncomingConnections: data.search_results_page })
         } else {

--- a/frontend/website/components/submissions/connections.js
+++ b/frontend/website/components/submissions/connections.js
@@ -60,7 +60,7 @@ export default function Connections({ submissionDataResponse, id }) {
         <>
             <Stack flexDirection='column' alignItems={'center'}>
                 <Typography variant='h4' gutterBottom>
-                    Connections
+                    Mentions
                 </Typography>
 
                 <Grid container rowSpacing={1} columnSpacing={1} justifyContent={'space-between'}>
@@ -69,7 +69,7 @@ export default function Connections({ submissionDataResponse, id }) {
                         {/* style={{ border: '1px solid #ccc', borderRadius: '4px', padding: '10px' }} */}
                         <Typography variant='h6' gutterBottom>
 
-                            {"Incoming connections" + " "}
+                            {"All submissions that mention this one" + " "}
 
                             <Tooltip title="All submissions that mention this one ">
                                 <InfoOutlined fontSize="xs" />

--- a/frontend/website/components/submissions/submissionDetails.js
+++ b/frontend/website/components/submissions/submissionDetails.js
@@ -123,7 +123,7 @@ export default function SubmissionDetails(subData) {
 
 
     async function copyPageUrl() {
-        const linkToCopy = WEBSITE_URL + GET_SUBMISSION_ENDPOINT + "/" + submissionId;
+        const linkToCopy = WEBSITE_URL + 'submissions/' + submissionId;
         try {
             await navigator.clipboard
                 .writeText(linkToCopy)

--- a/frontend/website/components/submissions/submissionDetails.js
+++ b/frontend/website/components/submissions/submissionDetails.js
@@ -365,6 +365,10 @@ export default function SubmissionDetails(subData) {
             setSnackBarProps({ isSnackBarOpen: true })
             setSnackBarProps({ snackBarSeverity: 'success' });
             setSnackBarProps({ snackBarMessage: 'Saved successfully!' })
+            // change display url
+            // in response get submission dispaly irl and set it herE?
+            // TODO
+            setSubmissionProps({ submissionDisplayUrl: submissionSourceUrl })
             // window.location.reload();
         }
         else {

--- a/frontend/website/components/submissions/submissionDetails.js
+++ b/frontend/website/components/submissions/submissionDetails.js
@@ -617,8 +617,22 @@ export default function SubmissionDetails(subData) {
                                     ? submissionCommunitiesNamesList.map((link, i) => [i > 0, link])
                                     : ""}
                                 {submissionData.submission.type === "webpage" &&
-                                    <Typography>
-                                        "Webpage"
+                                    <Typography
+                                        style={{
+                                            fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+                                            fontWeight: "500",
+                                            fontSize: "0.8125rem",
+                                            lineHeight: "1.75",
+                                            letterSpacing: "0.02857em",
+                                            textTransform: "uppercase",
+                                            // color: "#1976D2",
+                                            padding: "3px 7px",
+                                            marginRight: "5px",
+                                            textDecoration: "none",
+                                            background: "#DCDCDC",
+                                        }}
+                                    >
+                                        Webpage
                                     </Typography>
                                 }
                             </div>

--- a/frontend/website/components/submissions/submissionDetails.js
+++ b/frontend/website/components/submissions/submissionDetails.js
@@ -1,6 +1,6 @@
 import jsCookie from "js-cookie";
 import { ContentCopy, Delete, LocalLibraryOutlined, LocalLibraryRounded, LocalLibraryTwoTone, Save, Edit, CloseOutlined, Close } from '@mui/icons-material';
-import { Box, Checkbox, FormControl, IconButton, InputLabel, Link, ListItemText, Tooltip, Menu, MenuItem, OutlinedInput, Select, Stack, Typography, Grid, Button, ButtonGroup, Snackbar, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material';
+import { Box, Checkbox, FormControl, IconButton, InputLabel, Link, ListItemText, Tooltip, Menu, MenuItem, OutlinedInput, Select, Stack, Typography, Grid, Button, ButtonGroup, Snackbar, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, TextField } from '@mui/material';
 import { React, useState, useEffect } from 'react';
 import { BASE_URL_CLIENT, GET_SUBMISSION_ENDPOINT, SEARCH_ENDPOINT, WEBSITE_URL } from '../../static/constants';
 import SubmissionStatistics from "./stats";
@@ -33,6 +33,7 @@ export default function SubmissionDetails(subData) {
         submissionDisplayUrl,
         submissionLastModified,
         submissionDate,
+        submisssionRedirectUrl,
         isAConnection,
         setSubmissionProps
     } = useSubmissionStore();
@@ -406,6 +407,44 @@ export default function SubmissionDetails(subData) {
         setSubmissionProps({ ...submissionMode, submissionMode: "view" });
     }
 
+
+    const [feedbackMessage, setFeedbackMessage] = useState("");
+
+    const [openFeedbackForm, setOpenFeedbackForm] = useState(false);
+
+    const handleClickOpenFeedbackForm = () => {
+        setOpenFeedbackForm(true);
+    };
+    const handleMessageType = (event) => {
+        setFeedbackMessage(event.target.value);
+    };
+
+    const handleCancelFeedbackForm = () => {
+        setFeedbackMessage("");
+        setOpenFeedbackForm(false);
+        handleCloseOtherOptionsMenu();
+    };
+
+    const handleCreateFeedbackForm = async (event) => {
+        //send feedback
+        var URL = BASE_URL_CLIENT + "feedback" + "/";
+        const res = await fetch(URL, {
+            method: "POST",
+            body: JSON.stringify({
+                submission_id: submissionId,
+                message: feedbackMessage,
+            }),
+            headers: new Headers({
+                Authorization: jsCookie.get("token"),
+                "Content-Type": "application/json",
+            }),
+        });
+        const response = await res.json();
+        setOpenFeedbackForm(false);
+        setFeedbackMessage("");
+        handleCloseOtherOptionsMenu();
+    };
+
     useEffect(() => {
         getSubmissionData();
     }, []);
@@ -490,11 +529,44 @@ export default function SubmissionDetails(subData) {
                                     }}
                                 >
                                     {otherMenuOptions.map((option) => (
-                                        <MenuItem key={option} selected={option === 'Report Submission'} onClick={() => { console.log('need to report'); handleCloseOtherOptionsMenu(); }}>
+                                        <MenuItem key={option} selected={option === 'Report Submission'} onClick={handleClickOpenFeedbackForm}>
                                             {option}
                                         </MenuItem>
                                     ))}
                                 </Menu>
+                                <Dialog open={openFeedbackForm}>
+                                    <DialogTitle>
+                                        {" "}
+                                        Report submission: {" "}
+                                        <a
+                                            style={{ fontSize: "20px" }}
+                                            href={submisssionRedirectUrl}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            {submissionTitle}
+                                        </a>
+                                    </DialogTitle>
+                                    <DialogContent>
+                                        <DialogContentText>
+                                        </DialogContentText>
+                                        <TextField
+                                            autoFocus
+                                            margin="dense"
+                                            id="message"
+                                            name="message"
+                                            value={feedbackMessage}
+                                            onChange={handleMessageType}
+                                            label="Description"
+                                            fullWidth
+                                            variant="standard"
+                                        />
+                                    </DialogContent>
+                                    <DialogActions>
+                                        <Button onClick={handleCancelFeedbackForm}>Cancel</Button>
+                                        <Button onClick={handleCreateFeedbackForm}>Send</Button>
+                                    </DialogActions>
+                                </Dialog>
                                 <Dialog open={openDelete} onClose={handleCloseDelete}>
                                     <DialogTitle style={{ width: "500px" }}>
                                         {" "}

--- a/frontend/website/components/submissions/submissionDetails.js
+++ b/frontend/website/components/submissions/submissionDetails.js
@@ -280,14 +280,23 @@ export default function SubmissionDetails(subData) {
 
             const response = await res.json();
             if (response.status == "ok") {
+
+
+                setSnackBarProps({ isSnackBarOpen: true })
+                setSnackBarProps({ snackBarSeverity: 'success' });
+                setSnackBarProps({ snackBarMessage: 'Submission removed from community!' })
+
                 setSeverity("success");
                 setMessage("Submission removed from community.");
                 handleClick();
                 handleCloseDelete();
                 window.location.reload();
             } else {
-                setSeverity("error");
-                setMessage(response.message);
+
+                setSnackBarProps({ isSnackBarOpen: true })
+                setSnackBarProps({ snackBarSeverity: 'error' });
+                setSnackBarProps({ snackBarMessage: 'Cannot remove from community' })
+
                 handleClick();
             }
         }
@@ -789,7 +798,7 @@ export default function SubmissionDetails(subData) {
                     autoHideDuration={1000}
                     onClick={closeSnackbar}
                     message={snackBarMessage}
-                    severity={snackBarSeverity}
+                    severity={"red"}
                     onClose={closeSnackbar}
                 />
 

--- a/frontend/website/components/submissions/submissionDetails.js
+++ b/frontend/website/components/submissions/submissionDetails.js
@@ -639,127 +639,127 @@ export default function SubmissionDetails(subData) {
 
                         </div>
 
-                        <div style={{
-                            display: "flex",
-                            flex: 1,
-                        }}>
-                            <FormControl
-                                sx={{ width: "100px" }}
-                                size="small"
-                            >
-                                <InputLabel
-                                    id="demo-multiple-checkbox-label"
-                                    sx={{ width: 150, fontSize: "0.8rem" }} // Adjusting label width and font size
-                                >
-                                    Add
-                                </InputLabel>
-
-                                <Select
-                                    labelId="demo-multiple-checkbox-label"
-                                    id="demo-multiple-checkbox"
-                                    value={submissionSaveCommunityIDList}
-                                    // value={saveCommunityIDList}
-                                    onChange={handleSaveDropdownChange}
-                                    sx={{ borderRadius: "4px 0 0 4px", fontSize: "0.8rem" }} // Adjusting border radius and font size
-                                    input={
-                                        <OutlinedInput label="Add Community" />
-                                    }
-                                    renderValue={(selected) =>
-                                        selected
-                                            .map((x) => submissionCommunitiesNameMap[x])
-                                            .join(", ")
-                                    }
-                                    MenuProps={MenuProps}
-                                >
-                                    {/* {saveCommunityID.map((item) => ( */}
-                                    {submissionSaveCommunityID && submissionSaveCommunityID.map((item) => (
-                                        <MenuItem key={item} value={item}
-                                        >
-                                            <Checkbox
-                                                size="small"
-                                                checked={
-                                                    submissionSaveCommunityIDList.indexOf(item) > -1
-                                                }
-                                            />
-                                            <ListItemText
-                                                primaryTypographyProps={{ fontSize: '0.8rem' }}
-                                                primary={submissionCommunitiesNameMap[item]}
-                                            />
-                                        </MenuItem>
-
-                                    ))}
-                                </Select>
-                            </FormControl>
-                            <Tooltip title="Add to community">
-                                <IconButton
+                        {submissionData.submission.type !== "webpage" && <>
+                            <div style={{
+                                display: "flex",
+                                flex: 1,
+                            }}>
+                                <FormControl
+                                    sx={{ width: "100px" }}
                                     size="small"
-                                    sx={{ padding: "4px", borderColor: "green", borderRadius: "0 5px 5px 0", borderWidth: "1px", borderStyle: "solid" }}
-                                    onClick={saveSubmission}>
-                                    <Save fontSize="small" /> {/* Adjusting icon size */}
-                                </IconButton>
-                            </Tooltip>
-                        </div>
-
-
-
-                        <div style={{
-                            display: "flex",
-                            flex: 1,
-                        }}>
-                            <FormControl
-                                sx={{ width: "100px" }}
-                                size="small"
-                            >
-                                <InputLabel
-                                    id="demo-multiple-checkbox-label"
-                                    sx={{ fontSize: "0.8rem" }}
                                 >
-                                    Remove
-                                </InputLabel>
-                                <Select
-                                    labelId="demo-multiple-checkbox-label"
-                                    id="demo-multiple-checkbox"
-                                    // value={removeCommunityIDList}
-                                    value={submissionRemoveCommunityIDList}
-                                    onChange={handleRemoveDropdownChange}
-                                    input={
-                                        <OutlinedInput label="Remove Community" />
-                                    }
-                                    sx={{ borderRadius: "4px 0 0 4px", fontSize: "0.8rem" }}
-                                    renderValue={(selected) =>
-                                        selected
-                                            .map((x) => submissionCommunitiesNameMap[x])
-                                            .join(", ")
-                                    }
-                                    MenuProps={MenuProps}>
-                                    {/* {removeCommunityID.map((item) => ( */}
-                                    {submissionRemoveCommunityID && submissionRemoveCommunityID.map((item) => (
-                                        <MenuItem key={item} value={item}
-                                        >
-                                            <Checkbox
-                                                size="small"
-                                                checked={submissionRemoveCommunityIDList.indexOf(item) > -1}
-                                            />
-                                            <ListItemText
-                                                primaryTypographyProps={{ fontSize: '0.8rem' }}
-                                                primary={submissionCommunitiesNameMap[item]}
-                                            />
-                                        </MenuItem>
+                                    <InputLabel
+                                        id="demo-multiple-checkbox-label"
+                                        sx={{ width: 150, fontSize: "0.8rem" }} // Adjusting label width and font size
+                                    >
+                                        Add
+                                    </InputLabel>
 
+                                    <Select
+                                        labelId="demo-multiple-checkbox-label"
+                                        id="demo-multiple-checkbox"
+                                        value={submissionSaveCommunityIDList}
+                                        // value={saveCommunityIDList}
+                                        onChange={handleSaveDropdownChange}
+                                        sx={{ borderRadius: "4px 0 0 4px", fontSize: "0.8rem" }} // Adjusting border radius and font size
+                                        input={
+                                            <OutlinedInput label="Add Community" />
+                                        }
+                                        renderValue={(selected) =>
+                                            selected
+                                                .map((x) => submissionCommunitiesNameMap[x])
+                                                .join(", ")
+                                        }
+                                        MenuProps={MenuProps}
+                                    >
+                                        {/* {saveCommunityID.map((item) => ( */}
+                                        {submissionSaveCommunityID && submissionSaveCommunityID.map((item) => (
+                                            <MenuItem key={item} value={item}
+                                            >
+                                                <Checkbox
+                                                    size="small"
+                                                    checked={
+                                                        submissionSaveCommunityIDList.indexOf(item) > -1
+                                                    }
+                                                />
+                                                <ListItemText
+                                                    primaryTypographyProps={{ fontSize: '0.8rem' }}
+                                                    primary={submissionCommunitiesNameMap[item]}
+                                                />
+                                            </MenuItem>
 
-                                    ))}
-                                </Select>
-                            </FormControl>
-                            <Tooltip title="Remove from community">
-                                <IconButton
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                                <Tooltip title="Add to community">
+                                    <IconButton
+                                        size="small"
+                                        sx={{ padding: "4px", borderColor: "green", borderRadius: "0 5px 5px 0", borderWidth: "1px", borderStyle: "solid" }}
+                                        onClick={saveSubmission}>
+                                        <Save fontSize="small" /> {/* Adjusting icon size */}
+                                    </IconButton>
+                                </Tooltip>
+                            </div>
+
+                            <div style={{
+                                display: "flex",
+                                flex: 1,
+                            }}>
+                                <FormControl
+                                    sx={{ width: "100px" }}
                                     size="small"
-                                    sx={{ padding: "4px", borderColor: "red", borderRadius: "0 5px 5px 0", borderWidth: "1px", borderStyle: "solid" }}
-                                    onClick={deleteSubmissionfromCommunity}
                                 >
-                                    <Delete fontSize="small" /> {/* Adjusting icon size */}
-                                </IconButton>
-                            </Tooltip>
-                        </div>
+                                    <InputLabel
+                                        id="demo-multiple-checkbox-label"
+                                        sx={{ fontSize: "0.8rem" }}
+                                    >
+                                        Remove
+                                    </InputLabel>
+                                    <Select
+                                        labelId="demo-multiple-checkbox-label"
+                                        id="demo-multiple-checkbox"
+                                        // value={removeCommunityIDList}
+                                        value={submissionRemoveCommunityIDList}
+                                        onChange={handleRemoveDropdownChange}
+                                        input={
+                                            <OutlinedInput label="Remove Community" />
+                                        }
+                                        sx={{ borderRadius: "4px 0 0 4px", fontSize: "0.8rem" }}
+                                        renderValue={(selected) =>
+                                            selected
+                                                .map((x) => submissionCommunitiesNameMap[x])
+                                                .join(", ")
+                                        }
+                                        MenuProps={MenuProps}>
+                                        {/* {removeCommunityID.map((item) => ( */}
+                                        {submissionRemoveCommunityID && submissionRemoveCommunityID.map((item) => (
+                                            <MenuItem key={item} value={item}
+                                            >
+                                                <Checkbox
+                                                    size="small"
+                                                    checked={submissionRemoveCommunityIDList.indexOf(item) > -1}
+                                                />
+                                                <ListItemText
+                                                    primaryTypographyProps={{ fontSize: '0.8rem' }}
+                                                    primary={submissionCommunitiesNameMap[item]}
+                                                />
+                                            </MenuItem>
+
+
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                                <Tooltip title="Remove from community">
+                                    <IconButton
+                                        size="small"
+                                        sx={{ padding: "4px", borderColor: "red", borderRadius: "0 5px 5px 0", borderWidth: "1px", borderStyle: "solid" }}
+                                        onClick={deleteSubmissionfromCommunity}
+                                    >
+                                        <Delete fontSize="small" /> {/* Adjusting icon size */}
+                                    </IconButton>
+                                </Tooltip>
+                            </div>
+                        </>}
 
 
                         <div style={{

--- a/frontend/website/components/submissions/submissionGraph.js
+++ b/frontend/website/components/submissions/submissionGraph.js
@@ -128,7 +128,7 @@ export default function SubmissionGraph({ id, target }) {
 
     const handleNodeClick = useCallback(
         async (node) => {
-            setLoading(true);
+            // setLoading(true);
             const res = await fetch(BASE_URL_CLIENT + "submission/" + node.id, {
                 method: "GET",
                 headers: new Headers({
@@ -146,12 +146,22 @@ export default function SubmissionGraph({ id, target }) {
 
             // Complete Loading and Change URL
 
-            setLoading(false);
+            // setLoading(false);
             const nextURL = WEBSITE_URL + 'submissions/' + sourceRef.current + "?target=" + node.id;
             window.history.replaceState(null, "", nextURL);
         },
         [graph, setGraph]
     );
+
+    const handleNodeClickV2 = useCallback(
+        async (node) => {
+            const url = `${WEBSITE_URL}/submissions/${node.id}`;
+            // Open the URL in a new tab
+            window.open(url, '_blank'); // 
+        },
+        [graph, setGraph]
+    );
+
 
     useEffect(() => {
         sourceRef.current = source;
@@ -177,7 +187,7 @@ export default function SubmissionGraph({ id, target }) {
                     distance={300}
                     zoom={1}
                     backgroundColor={'#e5e5e5'}
-                    onNodeClick={handleNodeClick}
+                    onNodeClick={handleNodeClickV2}
                     nodeLabel={handleNodeLabel}
                     linkDirectionalArrowLength={3.5}
                     linkDirectionalArrowRelPos={1}

--- a/frontend/website/pages/notes/[id].js
+++ b/frontend/website/pages/notes/[id].js
@@ -163,7 +163,6 @@ function Notes({ data }) {
       const response = await res.json();
       if (res.status != 200) {
         try {
-          alert(response.message);
         } catch (error) {
           alert("Something went wrong. Please try again later");
         }

--- a/frontend/website/pages/submissions/[subId].js
+++ b/frontend/website/pages/submissions/[subId].js
@@ -139,7 +139,7 @@ export default function SubmissionPage({ errorCode, data, id, target }) {
   return (<>
 
     <Head>
-      <title>{'Submission - Textdata'}</title>
+      <title>{`${submissionTitle} - Textdata`}</title>
       <link rel="icon" href="/images/tree32.png" />
     </Head>
 

--- a/frontend/website/pages/submissions/[subId].js
+++ b/frontend/website/pages/submissions/[subId].js
@@ -40,7 +40,6 @@ export default function SubmissionPage({ errorCode, data, id, target }) {
 
 
   useEffect(() => {
-    console.log(data)
 
     setSubmissionProps({ submissionTitle: data.submission.explanation });
     setSubmissionProps({ submissionType: data.submission.type })
@@ -127,7 +126,6 @@ export default function SubmissionPage({ errorCode, data, id, target }) {
     });
     const response = await res.json();
     if (res.status == 200) {
-      console.log('+ response')
       if (method == "edit" || method == "reply") {
         console.log('need reload now!')
         window.location.reload();


### PR DESCRIPTION
- [x] When a community isn't selected for a reply, there seems to be a localhost alert error being thrown (guessing this was for debugging?)
- [x] The display URL update on edit (need to change backend response)
- [x] Removing a submission from a community should trigger the snackbar saying the error message returned by the backend
- [x] Rename connections

"Add Incoming Connection" --> "Make Submission with Mention"
"Connections" --> "Mentions"
"Incoming connections" --> "All submissions that mention this one"
"Reply to ..." can just be the hyperlinked title (i.e., we can remove the "Reply to")

- [x] The report functionality : call the old feedback API and let the user describe why they are reporting
- [x] The submission page's browser title should be the submission title (line 142 in [subid].js)
- [x] Copy url bug  http://localhost:8080/submission//65c2f7b3e7082a0a852e5cad
- [x] Method for finding the mentions- This can be done in the backend instead of calling the search API directly- update find_connections in functional.py (line 1792), and then return the connections in the "connections" field of the submission to the frontend. 
- [x] Clicking the graph doesn't open the new tab for that submission
- [x] Add toggle on viewing webpages for display the add/remove from community.
- [x] It appears that the community for a webpage is displayed with quotes: ' "Webpage" '